### PR TITLE
Adds simple scan function.

### DIFF
--- a/src/main/scala/net/fnothaft/snark/NestedIndex.scala
+++ b/src/main/scala/net/fnothaft/snark/NestedIndex.scala
@@ -27,7 +27,5 @@ case class NestedIndex(nest: Int, idx: Int) extends Ordered[NestedIndex] {
     }
   }
 
-  def equals(that: NestedIndex): Boolean = (nest == that.nest && idx == that.idx)
-
   override def toString(): String = "NestedIndex(" + nest + ", " + idx + ")"
 }


### PR DESCRIPTION
Adds a prefix-scan function that can be applied across the whole RDD (as opposed to a segmented scan).
